### PR TITLE
Chop nameprefix if too long

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "role" {
-  name_prefix        = "${var.name}-service-role"
+  name_prefix = "${join("", slice(split("", var.name), 0, length(var.name) > 31 ? 31 : length(var.name)))}"
 
   # from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
   assume_role_policy = <<END
@@ -16,13 +16,12 @@ resource "aws_iam_role" "role" {
 END
 }
 
-
 resource "aws_iam_role_policy" "policy" {
   role        = "${aws_iam_role.role.id}"
-  name_prefix = "${var.name}-service-policy"
+  name_prefix = "${join("", slice(split("", var.name), 0, length(var.name) > 31 ? 31 : length(var.name)))}"
 
   # from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html (step 7)
-  policy      = <<END
+  policy = <<END
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_service" "service" {
 }
 
 resource "aws_alb_target_group" "target_group" {
-  name                 = "${var.name}"
+  name = "${join("", slice(split("", var.name), 0, length(var.name) > 31 ? 31 : length(var.name)))}"
 
   # port will be set dynamically, but for some reason AWS requires a value
   port                 = "31337"

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -26,6 +26,14 @@ module "service" {
   task_definition = "test-taskdef"
 }
 
+module "service_with_long_name" {
+  source = "../.."
+
+  name            = "test-service-humptydumptysatonawallhumptydumptyhadagreatfall"
+  vpc_id          = "test-vpc"
+  task_definition = "test-taskdef"
+}
+
 module "role" {
   source = "../.."
 

--- a/test/test_load_balanced_ecs_service.py
+++ b/test/test_load_balanced_ecs_service.py
@@ -18,7 +18,7 @@ class TestCreateTaskdef(unittest.TestCase):
     def setUp(self):
         check_call([ 'terraform', 'get', 'test/infra' ])
 
-    
+
     def test_create_target_group(self):
         output = check_output([
             'terraform',
@@ -108,7 +108,7 @@ class TestCreateTaskdef(unittest.TestCase):
                 assume_role_policy: "{assume_role_policy}"
                 create_date:        "<computed>"
                 name:               "<computed>"
-                name_prefix:        "test-service-service-role"
+                name_prefix:        "test-service"
                 path:               "/"
                 unique_id:          "<computed>"
         """).strip().format(assume_role_policy=_terraform_escape_value(
@@ -149,7 +149,7 @@ class TestCreateTaskdef(unittest.TestCase):
         assert dedent("""
             + module.policy.aws_iam_role_policy.policy
                 name:        "<computed>"
-                name_prefix: "test-service-service-policy"
+                name_prefix: "test-service"
                 policy:      "{service_policy_doc}"
                 role:        "${{aws_iam_role.role.id}}"
         """).strip().format(service_policy_doc=_terraform_escape_value(


### PR DESCRIPTION
Nameprefix cannot be longer than 32 characters and given situation with long(ish) component name it's easy to cross 32 characters given we also have suffix `service-role` (this came out of testing via Hypothesis in another Terraform module which relies on this module).

Given this is name prefix for a specific resource (either role or role policy) I removed the suffix and added condition in which, if passed service name will cross 32 characters it'll get chopped at 32
characters.