### PR TITLE
Fix dependency issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,12 +25,18 @@ resource "aws_ecs_service" "service" {
     create_before_destroy = true
   }
 
-  depends_on = ["null_resource.alb_listener_arn"]
+  depends_on = ["null_resource.alb_listener_arn", "null_resource.alb_arn"]
 }
 
 resource "null_resource" "alb_listener_arn" {
   triggers {
     alb_listener_arn = "${var.alb_listener_arn}"
+  }
+}
+
+resource "null_resource" "alb_arn" {
+  triggers {
+    alb_name = "${var.alb_arn}"
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "target_group_arn" {
-  value = "${aws_alb_target_group.target_group.arn}"
+  value       = "${aws_alb_target_group.target_group.arn}"
   description = "The ARN of the target group for use by ALB listener rules (e.g. as a parameter to the tf_alb_listener_rules module: https://github.com/mergermarket/tf_alb_listener_rules)."
 }
 

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -59,5 +59,5 @@ module "all" {
 }
 
 output "target_group_arn" {
-    value = "${module.service.target_group_arn}"
+  value = "${module.service.target_group_arn}"
 }

--- a/test/test_load_balanced_ecs_service.py
+++ b/test/test_load_balanced_ecs_service.py
@@ -240,4 +240,4 @@ class TestCreateTaskdef(unittest.TestCase):
             'test/infra'
         ]).decode('utf-8')
 
-        assert "Plan: 5 to add, 0 to change, 0 to destroy." in output
+        assert "Plan: 6 to add, 0 to change, 0 to destroy." in output

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,8 @@ variable "alb_listener_arn" {
   description = "We need this to be available before the service can be created"
   default     = ""
 }
+
+variable "alb_arn" {
+  description = "The ARN of the ALB (used to ensure the ALB exists before the target group is associated with the service, since otherwise it fails)."
+  default     = ""
+}


### PR DESCRIPTION
If a user of this module supplies an ALB ARN it will ensure that the
ALB is created before the target group is associated with the service -
otherwise this causes an error the first time
(https://github.com/hashicorp/terraform/issues/12634).