### PR TITLE
Changing the way the - characters are stripped

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "null_resource" "alb_arn" {
 }
 
 resource "aws_alb_target_group" "target_group" {
-  name = "${join("", slice(split("", var.name), 0, length(var.name) > 31 ? 31 : length(var.name)))}"
+  name = "${replace(replace(var.name, "/(.{0,32}).*/", "$1"), "/^-+|-+$/", "")}"
 
   # port will be set dynamically, but for some reason AWS requires a value
   port                 = "31337"

--- a/test/test_load_balanced_ecs_service.py
+++ b/test/test_load_balanced_ecs_service.py
@@ -183,7 +183,7 @@ class TestCreateTaskdef(unittest.TestCase):
                 health_check.0.protocol:            "HTTP"
                 health_check.0.timeout:             "4"
                 health_check.0.unhealthy_threshold: "2"
-                name:                               "test-service-humptydumptysatona"
+                name:                               "test-service-humptydumptysatonaw"
         """).strip() # noqa
 
         assert expected_role_plan in output


### PR DESCRIPTION
When we run the tests, if the alb_target_group_name has a hypen (-) at
the end the terraform fails. This changes strips that character from the
befinning and the end.