### PR TITLE
Perameterise min and max healthy percentage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,11 @@
 resource "aws_ecs_service" "service" {
-  name            = "${var.name}"
-  cluster         = "${var.cluster}"
-  task_definition = "${var.task_definition}"
-  desired_count   = "${var.desired_count}"
-  iam_role        = "${aws_iam_role.role.arn}"
+  name                               = "${var.name}"
+  cluster                            = "${var.cluster}"
+  task_definition                    = "${var.task_definition}"
+  desired_count                      = "${var.desired_count}"
+  iam_role                           = "${aws_iam_role.role.arn}"
+  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
 
   load_balancer {
     target_group_arn = "${var.target_group_arn}"

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -57,3 +57,13 @@ module "all" {
   task_definition = "test-taskdef"
   target_group_arn = "some-target-group-arn"
 }
+
+module "service_with_custom_min_and_max_perecent" {
+  source = "../.."
+
+  name                               = "test-service"
+  task_definition                    = "test-taskdef"
+  target_group_arn                   = "some-target-group-arn"
+  deployment_minimum_healthy_percent = "0"
+  deployment_maximum_percent         = "100"
+}

--- a/test/test_load_balanced_ecs_service.py
+++ b/test/test_load_balanced_ecs_service.py
@@ -182,6 +182,22 @@ class TestCreateTaskdef(unittest.TestCase):
             expected_service_policy_doc
         )) in output
 
+    def test_min_and_max_perecent(self):
+        output = check_output([
+            'terraform',
+            'plan',
+            '-no-color',
+            '-target=module.service_with_custom_min_and_max_perecent',
+            'test/infra'
+        ]).decode('utf-8')
+
+        assert dedent("""
+           + module.service_with_custom_min_and_max_perecent.aws_ecs_service.service
+               cluster:                                 "default"
+               deployment_maximum_percent:              "100"
+               deployment_minimum_healthy_percent:      "0"
+        """).strip() in output
+
     def test_correct_number_of_resources(self):
         output = check_output([
             'terraform',

--- a/variables.tf
+++ b/variables.tf
@@ -82,3 +82,13 @@ variable "health_check_matcher" {
   type        = "string"
   default     = "200-299"
 }
+
+variable "deployment_minimum_healthy_percent" {
+  description = "The minimumHealthyPercent represents a lower limit on the number of your service's tasks that must remain in the RUNNING state during a deployment, as a percentage of the desiredCount (rounded up to the nearest integer)."
+  default     = "100"
+}
+
+variable "deployment_maximum_percent" {
+  description = "The maximumPercent parameter represents an upper limit on the number of your service's tasks that are allowed in the RUNNING or PENDING state during a deployment, as a percentage of the desiredCount (rounded down to the nearest integer)."
+  default     = "200"
+}


### PR DESCRIPTION
So that we can deploy singleton services like confluence.