### PR TITLE
Prevent services being removed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,8 @@ resource "aws_ecs_service" "service" {
     type  = "spread"
     field = "instanceId"
   }
+  
+  create_before_destroy = true
 }
 
 resource "aws_ecs_service" "service_no_loadbalancer" {


### PR DESCRIPTION
This should cause an error when the ordered_placement_strategy change is applied, rather than the service being recreated.