### PR TITLE
Pack and distinct instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
 
   placement_constraints {
     type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"}"
-    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == TRUE"}"
+    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "registeredAt > 2000-01-01"}"
   }
   
 }

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "service" {
   }
   
   placement_constraints {
-    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "null"}" 
+    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -69,11 +69,8 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
   }
 
   placement_constraints {
-    type = "distinctInstance"
+    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"}"
+    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == TRUE"}"
   }
-
-  placement_constraints {
-    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
-  }
-
+  
 }

--- a/main.tf
+++ b/main.tf
@@ -57,11 +57,6 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
     type  = "spread"
     field = "attribute:ecs.availability-zone"
   }
-
-  ordered_placement_strategy {
-    type  = "binpack"
-    field = "cpu"
-  }
   
   ordered_placement_strategy {
     type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"

--- a/main.tf
+++ b/main.tf
@@ -23,13 +23,13 @@ resource "aws_ecs_service" "service" {
   }
   
   ordered_placement_strategy {
-    type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
-    field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
+    type  = "${lower(var.pack_and_distinct) == "true" ? "binpack" : "spread"}"
+    field = "${lower(var.pack_and_distinct) == "true" ? "cpu" : "instanceId"}"
   }
 
   placement_constraints {
-    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"}"
-    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"}"
+    type = "${lower(var.pack_and_distinct) == "true" ? "distinctInstance" : "memberOf"}"
+    expression = "${lower(var.pack_and_distinct) == "true" ? "" : "agentConnected == true"}"
   }
 
   lifecycle {
@@ -55,13 +55,13 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
   }
   
   ordered_placement_strategy {
-    type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
-    field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
+    type  = "${lower(var.pack_and_distinct) == "true" ? "binpack" : "spread"}"
+    field = "${lower(var.pack_and_distinct) == "true" ? "cpu" : "instanceId"}"
   }
 
   placement_constraints {
-    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"}"
-    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"}"
+    type = "${lower(var.pack_and_distinct) == "true" ? "distinctInstance" : "memberOf"}"
+    expression = "${lower(var.pack_and_distinct) == "true" ? "" : "agentConnected == true"}"
   }
   
 }

--- a/main.tf
+++ b/main.tf
@@ -22,10 +22,19 @@ resource "aws_ecs_service" "service" {
     field = "attribute:ecs.availability-zone"
   }
 
+  # ordered_placement_strategy {
+  #   type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
+  #   field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
+  # }
+
   ordered_placement_strategy {
     type  = "spread"
     field = "instanceId"
   }
+
+  # placement_constraints {
+  #   type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
+  # }
 
   lifecycle {
     create_before_destroy = true
@@ -54,7 +63,17 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
     field = "cpu"
   }
   
+  ordered_placement_strategy {
+    type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
+    field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
+  }
+
   placement_constraints {
     type = "distinctInstance"
   }
+
+  placement_constraints {
+    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
+  }
+
 }

--- a/main.tf
+++ b/main.tf
@@ -23,13 +23,9 @@ resource "aws_ecs_service" "service" {
   }
 
   ordered_placement_strategy {
-    type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
-    field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
+    type  = "spread"
+    field = "instanceId"
   }
-  
-  # placement_constraints {
-  #   type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
-  # }
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -23,12 +23,12 @@ resource "aws_ecs_service" "service" {
   }
 
   ordered_placement_strategy {
-    type  = "binpack"
-    field = "cpu"
+    type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
+    field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
   }
   
   placement_constraints {
-    type = "distinctInstance"
+    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "null"}" 
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -27,9 +27,9 @@ resource "aws_ecs_service" "service" {
     field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
   }
   
-  placement_constraints {
-    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
-  }
+  # placement_constraints {
+  #   type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
+  # }
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -23,10 +23,14 @@ resource "aws_ecs_service" "service" {
   }
 
   ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+    type  = "binpack"
+    field = "cpu"
   }
   
+  placement_constraints {
+    type = "distinctInstance"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,11 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
   }
 
   ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+    type  = "binpack"
+    field = "cpu"
+  }
+  
+  placement_constraints {
+    type = "distinctInstance"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
 
   placement_constraints {
     type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"}"
-    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "registeredAt > 2000-01-01"}"
+    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"}"
   }
   
 }

--- a/main.tf
+++ b/main.tf
@@ -21,20 +21,16 @@ resource "aws_ecs_service" "service" {
     type  = "spread"
     field = "attribute:ecs.availability-zone"
   }
-
-  # ordered_placement_strategy {
-  #   type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
-  #   field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
-  # }
-
+  
   ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+    type  = "${lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"}"
+    field = "${lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"}"
   }
 
-  # placement_constraints {
-  #   type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : ""}" 
-  # }
+  placement_constraints {
+    type = "${lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"}"
+    expression = "${lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"}"
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/test/test_load_balanced_ecs_service.py
+++ b/test/test_load_balanced_ecs_service.py
@@ -30,30 +30,33 @@ class TestCreateTaskdef(unittest.TestCase):
 
         expected_service = dedent("""
 + module.service.aws_ecs_service.service
-      id:                                        <computed>
-      cluster:                                   "default"
-      deployment_maximum_percent:                "200"
-      deployment_minimum_healthy_percent:        "100"
-      desired_count:                             "3"
-      enable_ecs_managed_tags:                   "false"
-      health_check_grace_period_seconds:         "0"
-      iam_role:                                  "${aws_iam_role.role.arn}"
-      launch_type:                               <computed>
-      load_balancer.#:                           "1"
-      load_balancer.2878138410.container_name:   "app"
-      load_balancer.2878138410.container_port:   "8000"
-      load_balancer.2878138410.elb_name:         ""
-      load_balancer.2878138410.target_group_arn: "arn:aws-partition:service:eu-west-1:aws:resource"
-      name:                                      "test-service"
-      ordered_placement_strategy.#:              "2"
-      ordered_placement_strategy.0.field:        "attribute:ecs.availability-zone"
-      ordered_placement_strategy.0.type:         "spread"
-      ordered_placement_strategy.1.field:        "instanceId"
-      ordered_placement_strategy.1.type:         "spread"
-      placement_strategy.#:                      <computed>
-      platform_version:                          <computed>
-      scheduling_strategy:                       "REPLICA"
-      task_definition:                           "test-taskdef"
+      id:                                          <computed>
+      cluster:                                     "default"
+      deployment_maximum_percent:                  "200"
+      deployment_minimum_healthy_percent:          "100"
+      desired_count:                               "3"
+      enable_ecs_managed_tags:                     "false"
+      health_check_grace_period_seconds:           "0"
+      iam_role:                                    "${aws_iam_role.role.arn}"
+      launch_type:                                 <computed>
+      load_balancer.#:                             "1"
+      load_balancer.2878138410.container_name:     "app"
+      load_balancer.2878138410.container_port:     "8000"
+      load_balancer.2878138410.elb_name:           ""
+      load_balancer.2878138410.target_group_arn:   "arn:aws-partition:service:eu-west-1:aws:resource"
+      name:                                        "test-service"
+      ordered_placement_strategy.#:                "2"
+      ordered_placement_strategy.0.field:          "attribute:ecs.availability-zone"
+      ordered_placement_strategy.0.type:           "spread"
+      ordered_placement_strategy.1.field:          "instanceId"
+      ordered_placement_strategy.1.type:           "spread"
+      placement_constraints.#:                     "1"
+      placement_constraints.4028779950.expression: "agentConnected == true"
+      placement_constraints.4028779950.type:       "memberOf"
+      placement_strategy.#:                        <computed>
+      platform_version:                            <computed>
+      scheduling_strategy:                         "REPLICA"
+      task_definition:                             "test-taskdef"
 """)
 
         assert expected_service.replace(" ", "") in output.replace(" ", "")
@@ -144,30 +147,33 @@ class TestCreateTaskdef(unittest.TestCase):
         """).strip()
         expected_aws_ecs_service_plan = dedent("""
 + module.service_with_long_name.aws_ecs_service.service
-      id:                                        <computed>
-      cluster:                                   "default"
-      deployment_maximum_percent:                "200"
-      deployment_minimum_healthy_percent:        "100"
-      desired_count:                             "3"
-      enable_ecs_managed_tags:                   "false"
-      health_check_grace_period_seconds:         "0"
-      iam_role:                                  "${aws_iam_role.role.arn}"
-      launch_type:                               <computed>
-      load_balancer.#:                           "1"
-      load_balancer.2878138410.container_name:   "app"
-      load_balancer.2878138410.container_port:   "8000"
-      load_balancer.2878138410.elb_name:         ""
-      load_balancer.2878138410.target_group_arn: "arn:aws-partition:service:eu-west-1:aws:resource"
-      name:                                      "test-service-humptydumptysatonawallhumptydumptyhadagreatfall"
-      ordered_placement_strategy.#:              "2"
-      ordered_placement_strategy.0.field:        "attribute:ecs.availability-zone"
-      ordered_placement_strategy.0.type:         "spread"
-      ordered_placement_strategy.1.field:        "instanceId"
-      ordered_placement_strategy.1.type:         "spread"
-      placement_strategy.#:                      <computed>
-      platform_version:                          <computed>
-      scheduling_strategy:                       "REPLICA"
-      task_definition:                           "test-taskdef"
+      id:                                          <computed>
+      cluster:                                     "default"
+      deployment_maximum_percent:                  "200"
+      deployment_minimum_healthy_percent:          "100"
+      desired_count:                               "3"
+      enable_ecs_managed_tags:                     "false"
+      health_check_grace_period_seconds:           "0"
+      iam_role:                                    "${aws_iam_role.role.arn}"
+      launch_type:                                 <computed>
+      load_balancer.#:                             "1"
+      load_balancer.2878138410.container_name:     "app"
+      load_balancer.2878138410.container_port:     "8000"
+      load_balancer.2878138410.elb_name:           ""
+      load_balancer.2878138410.target_group_arn:   "arn:aws-partition:service:eu-west-1:aws:resource"
+      name:                                        "test-service-humptydumptysatonawallhumptydumptyhadagreatfall"
+      ordered_placement_strategy.#:                "2"
+      ordered_placement_strategy.0.field:          "attribute:ecs.availability-zone"
+      ordered_placement_strategy.0.type:           "spread"
+      ordered_placement_strategy.1.field:          "instanceId"
+      ordered_placement_strategy.1.type:           "spread"
+      placement_constraints.#:                     "1"
+      placement_constraints.4028779950.expression: "agentConnected == true"
+      placement_constraints.4028779950.type:       "memberOf"
+      placement_strategy.#:                        <computed>
+      platform_version:                            <computed>
+      scheduling_strategy:                         "REPLICA"
+      task_definition:                             "test-taskdef"
 """).strip() # noqa
 
         assert expected_role_plan.replace(" ", "") in output.replace(" ", "")
@@ -301,33 +307,36 @@ class TestCreateTaskdef(unittest.TestCase):
 
         expected_aws_ecs_service_plan = dedent("""
 + module.service_with_tags.aws_ecs_service.service
-      id:                                        <computed>
-      cluster:                                   "default"
-      deployment_maximum_percent:                "200"
-      deployment_minimum_healthy_percent:        "100"
-      desired_count:                             "3"
-      enable_ecs_managed_tags:                   "false"
-      health_check_grace_period_seconds:         "0"
-      iam_role:                                  "${aws_iam_role.role.arn}"
-      launch_type:                               <computed>
-      load_balancer.#:                           "1"
-      load_balancer.2878138410.container_name:   "app"
-      load_balancer.2878138410.container_port:   "8000"
-      load_balancer.2878138410.elb_name:         ""
-      load_balancer.2878138410.target_group_arn: "arn:aws-partition:service:eu-west-1:aws:resource"
-      name:                                      "test-service-with-tags"
-      ordered_placement_strategy.#:              "2"
-      ordered_placement_strategy.0.field:        "attribute:ecs.availability-zone"
-      ordered_placement_strategy.0.type:         "spread"
-      ordered_placement_strategy.1.field:        "instanceId"
-      ordered_placement_strategy.1.type:         "spread"
-      placement_strategy.#:                      <computed>
-      platform_version:                          <computed>
-      scheduling_strategy:                       "REPLICA"
-      tags.%:                                    "2"
-      tags.name1:                                "value1"
-      tags.name2:                                "value2"
-      task_definition:                           "test-taskdef"
+      id:                                          <computed>
+      cluster:                                     "default"
+      deployment_maximum_percent:                  "200"
+      deployment_minimum_healthy_percent:          "100"
+      desired_count:                               "3"
+      enable_ecs_managed_tags:                     "false"
+      health_check_grace_period_seconds:           "0"
+      iam_role:                                    "${aws_iam_role.role.arn}"
+      launch_type:                                 <computed>
+      load_balancer.#:                             "1"
+      load_balancer.2878138410.container_name:     "app"
+      load_balancer.2878138410.container_port:     "8000"
+      load_balancer.2878138410.elb_name:           ""
+      load_balancer.2878138410.target_group_arn:   "arn:aws-partition:service:eu-west-1:aws:resource"
+      name:                                        "test-service-with-tags"
+      ordered_placement_strategy.#:                "2"
+      ordered_placement_strategy.0.field:          "attribute:ecs.availability-zone"
+      ordered_placement_strategy.0.type:           "spread"
+      ordered_placement_strategy.1.field:          "instanceId"
+      ordered_placement_strategy.1.type:           "spread"
+      placement_constraints.#:                     "1"
+      placement_constraints.4028779950.expression: "agentConnected == true"
+      placement_constraints.4028779950.type:       "memberOf"
+      placement_strategy.#:                        <computed>
+      platform_version:                            <computed>
+      scheduling_strategy:                         "REPLICA"
+      tags.%:                                      "2"
+      tags.name1:                                  "value1"
+      tags.name2:                                  "value2"
+      task_definition:                             "test-taskdef"
 """).strip() # noqa
 
         assert expected_role_plan.replace(" ", "") in output.replace(" ", "")
@@ -343,34 +352,36 @@ class TestCreateTaskdef(unittest.TestCase):
             'test/infra'
         ]).decode('utf-8')
 
-        print(output)
-
         expected_service = dedent("""
 + module.service_with_grace_period.aws_ecs_service.service
-      id:                                        <computed>
-      cluster:                                   "default"
-      deployment_maximum_percent:                "200"
-      deployment_minimum_healthy_percent:        "100"
-      desired_count:                             "3"
-      enable_ecs_managed_tags:                   "false"
-      health_check_grace_period_seconds:         "15"
-      iam_role:                                  "${aws_iam_role.role.arn}"
-      launch_type:                               <computed>
-      load_balancer.#:                           "1"
-      load_balancer.2878138410.container_name:   "app"
-      load_balancer.2878138410.container_port:   "8000"
-      load_balancer.2878138410.elb_name:         ""
-      load_balancer.2878138410.target_group_arn: "arn:aws-partition:service:eu-west-1:aws:resource"
-      name:                                      "test-service"
-      ordered_placement_strategy.#:              "2"
-      ordered_placement_strategy.0.field:        "attribute:ecs.availability-zone"
-      ordered_placement_strategy.0.type:         "spread"
-      ordered_placement_strategy.1.field:        "instanceId"
-      ordered_placement_strategy.1.type:         "spread"
-      placement_strategy.#:                      <computed>
-      platform_version:                          <computed>
-      scheduling_strategy:                       "REPLICA"
-      task_definition:                           "test-taskdef"
+      id:                                          <computed>
+      cluster:                                     "default"
+      deployment_maximum_percent:                  "200"
+      deployment_minimum_healthy_percent:          "100"
+      desired_count:                               "3"
+      enable_ecs_managed_tags:                     "false"
+      health_check_grace_period_seconds:           "15"
+      iam_role:                                    "${aws_iam_role.role.arn}"
+      launch_type:                                 <computed>
+      load_balancer.#:                             "1"
+      load_balancer.2878138410.container_name:     "app"
+      load_balancer.2878138410.container_port:     "8000"
+      load_balancer.2878138410.elb_name:           ""
+      load_balancer.2878138410.target_group_arn:   "arn:aws-partition:service:eu-west-1:aws:resource"
+      name:                                        "test-service"
+      ordered_placement_strategy.#:                "2"
+      ordered_placement_strategy.0.field:          "attribute:ecs.availability-zone"
+      ordered_placement_strategy.0.type:           "spread"
+      ordered_placement_strategy.1.field:          "instanceId"
+      ordered_placement_strategy.1.type:           "spread"
+      placement_constraints.#:                     "1"
+      placement_constraints.4028779950.expression: "agentConnected == true"
+      placement_constraints.4028779950.type:       "memberOf"
+      placement_strategy.#:                        <computed>
+      platform_version:                            <computed>
+      scheduling_strategy:                         "REPLICA"
+      task_definition:                             "test-taskdef"
 """)
 
         assert expected_service.replace(" ", "") in output.replace(" ", "")
+        

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,8 @@ variable "health_check_grace_period_seconds" {
   type = "string"
   default = "0"
 }
+
+variable "distinct_task_placement" {
+  description = "Enable distinct instance and binpacking. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
+  type = "string"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -105,8 +105,8 @@ variable "health_check_grace_period_seconds" {
   default = "0"
 }
 
-variable "distinct_task_placement" {
-  description = "Enable distinct instance and binpacking. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
+variable "pack_and_distinct" {
+  description = "Enable distinct instance and task binpacking for better cluster utilisation. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
   type = "string"
   default = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -108,4 +108,5 @@ variable "health_check_grace_period_seconds" {
 variable "distinct_task_placement" {
   description = "Enable distinct instance and binpacking. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
   type = "string"
+  default = "false"
 }


### PR DESCRIPTION
Introduce variable that allows service to toggle their task placement strategy.

- Default behaviour remains to spread tasks on AZ and the instance.
- Setting to true will spread on AZ as well, but also binpacks on cpu whilst placing on distinct instances. This packing allows large clusters with auto scalers to more fully utilise their capacity.
